### PR TITLE
change path selector modal overflow behavior

### DIFF
--- a/lib/form.rb
+++ b/lib/form.rb
@@ -325,9 +325,9 @@ helpers do
       <button class="btn btn-dark mt-0 text-nowrap" data-bs-toggle="modal" data-bs-target="#modal-#{key}" tabindex="-1" onclick="ocForm.loadFiles('#{@script_name}', '#{current_path}', '#{current_type}', '#{key}', #{show_files}, '#{Dir.home}', true); return false;">Select Path</button>
     </div>
     <div class="modal" id="modal-#{key}">
-      <div class="modal-dialog modal-lg">
+      <div class="modal-dialog modal-lg style="overflow-y: initial !important;">
         <div class="modal-content">
-          <div class="modal-body">
+          <div class="modal-body" style="max-height: 80vh;overflow-y: auto;">
             <div class="container-fluid">
               <div class="row">
     HTML


### PR DESCRIPTION
I would prefer the path selector widget to work differently. It now creates a modal popup and if the folder contains a lot of files the modal overflows and you always have to scroll to the bottom to click on the select button. I would prefer a modal with fixed height and a scroll bar in the modal body to scroll through the file list. Thanks for this great app.