### PR TITLE
Consolidate querying both running and history jobs in pbspro

### DIFF
--- a/lib/schedulers/pbspro.rb
+++ b/lib/schedulers/pbspro.rb
@@ -96,22 +96,14 @@ class Pbspro < Scheduler
                                
     qstat = get_command_path("qstat", bin, bin_overrides)
 
-    # Try to get info for running jobs 
-    command = [ssh_wrapper, qstat, "-f -t", jobs.join(" ")].compact.join(" ")
-    stdout1, stderr1, status1 = Open3.capture3(command)
-    return nil, [stdout1, stderr1].join(" ") unless status1.success?
-
     info = {}
-    parse_qstat_output(stdout1, info)
-    remaining_jobs = jobs.reject { |id| info.key?(id) }
-    return info, nil if remaining_jobs.empty?
-
-    # Try to get info for completed jobs 
-    command = [ssh_wrapper, qstat, "-f -t -x", remaining_jobs.join(" ")].compact.join(" ")
-    stdout2, stderr2, status2 = Open3.capture3(command)
-    return nil, [stdout2, stderr2].join(" ") unless status2.success?
+    # Try to get info for both running and completed jobs 
+    # command = [ssh_wrapper, qstat, "-f -t -x", jobs.join(" ")].compact.join(" ")
+    command = [ssh_wrapper, qstat, "-f -t -x"].compact.join(" ")
+    stdout, stderr, status = Open3.capture3(command)
+    return nil, [stdout, stderr].join(" ") unless status.success?
   
-    parse_qstat_output(stdout2, info)
+    parse_qstat_output(stdout, info)
     return info, nil
   rescue Exception => e
     return nil, e.message


### PR DESCRIPTION
`qstat -x` command supports querying both current running and history jobs.
However, PBS Pro scheduler has a `job_history_duration` setting to specify the length of time that PBS will keep each job's history and `qstat -x` can only query jobs within this duration.

If a history job is older than the set duration, it cannot be found from `qstat -x`. If that job is recorded in OpenComposer, and OpenComposer tries to query its state, an error would occur.

``` bash
[dzhang01@sod-login01 composer]$ qstat -x
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
282.sod-pbs       sleep            dzhang01          00:00:00 F workq
284.sod-pbs       sleep            dzhang01          00:00:00 R workq

[dzhang01@sod-login01 composer]$ qstat 256.sod-pbs
qstat: Unknown Job Id 256.sod-pbs
```


