### PR TITLE
Fix history error

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -6,6 +6,7 @@ require "./lib/index"
 require "./lib/form"
 require "./lib/history"
 require "./lib/scheduler"
+require "fileutils"
 
 set :environment, :production
 #set :environment, :development


### PR DESCRIPTION
When the folder conf["data_dir"] doesn't exist (/home/user/composer), there is an Internal Server Error when trying to check the history if no jobs have been submitted from the composer. This change seems to fix the issue.