### PR TITLE
Enable showing calculation results in form.js

### DIFF
--- a/public/form.js
+++ b/public/form.js
@@ -657,8 +657,16 @@ ocForm.showLine = function(selectedValues, line, keys, widgets, canHide, separat
     }
   }
   // After variable substitution, replace the $[[ ]] section with the calculated result.
-  line = line.replace(/\$\[\[(.*?)\]\]/g, (_, expr) => eval(expr))
-  
+  line = line.replace(/\$\[\[(.*?)\]\]/g, (_, expr) => {
+    try {
+          // Return calculation result
+          return eval(expr);
+        } catch (e) {
+          // Nothing to do
+          return `$[[${expr}]]`;
+        }
+    });
+
   if (line) {
     selectedValues.push(line);
   }


### PR DESCRIPTION
Hi, 

I made a small improvement to allow calculation results to be displayed in the form.
In public/form.js, I added lines that evaluate and replace any parts wrapped in $[[ ]] after variable expansion.

Examples: $[[ #{var_1} * #{var_2} ]]
 
If expr returns an error, the content will be displayed as-is without any modification, ensuring that the page does not break.

I hope this small change helps improve the system. Please let me know if you have any feedback!

Thanks
